### PR TITLE
Update library for Stripe Terminal SDK 1.0.0

### DIFF
--- a/ios/RNStripeTerminal.h
+++ b/ios/RNStripeTerminal.h
@@ -12,12 +12,15 @@
 #import "StripeTerminal.h"
 #endif
 
-@interface RNStripeTerminal : RCTEventEmitter <RCTBridgeModule, SCPConnectionTokenProvider, SCPDiscoveryDelegate, SCPReaderInputDelegate, SCPTerminalDelegate> {
+@interface RNStripeTerminal : RCTEventEmitter <RCTBridgeModule, SCPConnectionTokenProvider, SCPDiscoveryDelegate, SCPReaderDisplayDelegate, SCPTerminalDelegate, SCPReaderSoftwareUpdateDelegate> {
 
     NSArray<SCPReader *> *readers;
     SCPReader *reader;
+    SCPPaymentIntent *intent;
+    SCPReaderSoftwareUpdate *update;
     SCPCancelable *pendingCreatePaymentIntent;
     SCPCancelable *pendingDiscoverReaders;
+    SCPCancelable *pendingInstallUpdate;
     SCPConnectionTokenCompletionBlock pendingConnectionTokenCompletionBlock;
     SCPReaderEvent lastReaderEvent;
 }

--- a/ios/RNStripeTerminal.m
+++ b/ios/RNStripeTerminal.m
@@ -43,6 +43,7 @@ static dispatch_once_t onceToken = 0;
              @"didRequestReaderDisplayMessage",
              @"didReportReaderEvent",
              @"didReportUnexpectedReaderDisconnect",
+             @"didReportLowBatteryWarning",
              @"didChangePaymentStatus",
              @"didChangeConnectionStatus",
              @"didDisconnectUnexpectedlyFromReader",

--- a/ios/RNStripeTerminal.m
+++ b/ios/RNStripeTerminal.m
@@ -26,13 +26,23 @@ static dispatch_once_t onceToken = 0;
              @"log",
              @"requestConnectionToken",
              @"readersDiscovered",
+             @"readerSoftwareUpdateProgress",
              @"readerDiscoveryCompletion",
              @"readerDisconnectCompletion",
              @"readerConnection",
+             @"updateCheck",
+             @"updateInstall",
              @"paymentCreation",
+             @"paymentIntentCreation",
+             @"paymentIntentRetrieval",
+             @"paymentMethodCollection",
+             @"paymentProcess",
+             @"paymentIntentCancel",
              @"didBeginWaitingForReaderInput",
-             @"didRequestReaderInputPrompt",
+             @"didRequestReaderInput",
+             @"didRequestReaderDisplayMessage",
              @"didReportReaderEvent",
+             @"didReportUnexpectedReaderDisconnect",
              @"didChangePaymentStatus",
              @"didChangeConnectionStatus",
              @"didDisconnectUnexpectedlyFromReader",
@@ -41,7 +51,8 @@ static dispatch_once_t onceToken = 0;
              @"paymentStatus",
              @"lastReaderEvent",
              @"abortCreatePaymentCompletion",
-             @"abortDiscoverReadersCompletion"
+             @"abortDiscoverReadersCompletion",
+             @"abortInstallUpdateCompletion"
              ];
 }
 
@@ -49,28 +60,27 @@ static dispatch_once_t onceToken = 0;
 {
     return @{
              @"DeviceTypeChipper2X": @(SCPDeviceTypeChipper2X),
-             @"DeviceTypeReaderSimulator": @(SCPDeviceTypeReaderSimulator),
-             
+
              @"DiscoveryMethodBluetoothScan": @(SCPDiscoveryMethodBluetoothScan),
              @"DiscoveryMethodBluetoothProximity": @(SCPDiscoveryMethodBluetoothProximity),
-             
-             @"PaymentIntentStatusRequiresSource": @(SCPPaymentIntentStatusRequiresSource),
+
+             @"PaymentIntentStatusRequiresPaymentMethod": @(SCPPaymentIntentStatusRequiresPaymentMethod),
              @"PaymentIntentStatusRequiresConfirmation": @(SCPPaymentIntentStatusRequiresConfirmation),
              @"PaymentIntentStatusRequiresCapture": @(SCPPaymentIntentStatusRequiresCapture),
              @"PaymentIntentStatusCanceled": @(SCPPaymentIntentStatusCanceled),
              @"PaymentIntentStatusSucceeded": @(SCPPaymentIntentStatusSucceeded),
-             
+
              @"ReaderEventCardInserted": @(SCPReaderEventCardInserted),
              @"ReaderEventCardRemoved": @(SCPReaderEventCardRemoved),
-             
+
              @"PaymentStatusNotReady": @(SCPPaymentStatusNotReady),
              @"PaymentStatusReady": @(SCPPaymentStatusReady),
-             @"PaymentStatusCollectingPaymentMethod": @(SCPPaymentStatusCollectingPaymentMethod),
-             @"PaymentStatusConfirmingPaymentIntent": @(SCPPaymentStatusConfirmingPaymentIntent),
-             
+             @"PaymentStatusWaitingForInput": @(SCPPaymentStatusWaitingForInput),
+             @"PaymentStatusProcessing": @(SCPPaymentStatusProcessing),
+
              @"ConnectionStatusNotConnected": @(SCPConnectionStatusNotConnected),
              @"ConnectionStatusConnected": @(SCPConnectionStatusConnected),
-             @"ConnectionStatusBusy": @(SCPConnectionStatusBusy),
+             @"ConnectionStatusConnecting": @(SCPConnectionStatusConnecting),
              };
 }
 
@@ -81,13 +91,17 @@ static dispatch_once_t onceToken = 0;
 
 - (void)terminal:(SCPTerminal *)terminal didUpdateDiscoveredReaders:(NSArray<SCPReader *>*)_readers {
     readers = _readers;
-    
+
     NSMutableArray *data = [NSMutableArray arrayWithCapacity:[readers count]];
     [readers enumerateObjectsUsingBlock:^(SCPReader *reader, NSUInteger idx, BOOL *stop) {
         [data addObject:[self serializeReader:reader]];
     }];
-    
+
     [self sendEventWithName:@"readersDiscovered" body:data];
+}
+
+- (void)terminal:(SCPTerminal *)terminal didReportReaderSoftwareUpdateProgress:(float)progress {
+    [self sendEventWithName:@"readerSoftwareUpdateProgress" body:[NSNumber numberWithFloat:progress]];
 }
 
 - (void)onLogEntry:(NSString * _Nonnull) logline {
@@ -106,7 +120,7 @@ RCT_EXPORT_METHOD(setConnectionToken:(NSString *)token error:(NSString *)errorMe
         } else {
             pendingConnectionTokenCompletionBlock(token, nil);
         }
-        
+
         pendingConnectionTokenCompletionBlock = nil;
     }
 }
@@ -115,7 +129,7 @@ RCT_EXPORT_METHOD(initialize) {
     dispatch_once(&onceToken, ^{
         [SCPTerminal setTokenProvider:self];
     });
-    
+
     SCPTerminal.shared.delegate = self;
     [SCPTerminal setLogListener:^(NSString * _Nonnull logline) {
         [self onLogEntry:logline];
@@ -126,16 +140,19 @@ RCT_EXPORT_METHOD(initialize) {
     // cleaned up from a previous initialization (e.g., due to hot reloading).
     [self abortDiscoverReaders];
     [self abortCreatePayment];
+    [self abortInstallUpdate];
 
     // When the module is initialized, assume the card has been removed.
     lastReaderEvent = SCPReaderEventCardRemoved;
 }
 
-RCT_EXPORT_METHOD(discoverReaders:(NSInteger *)deviceType method:(NSInteger *)method) {
+RCT_EXPORT_METHOD(discoverReaders:(NSInteger *)deviceType method:(NSInteger *)method simulated:(BOOL *)simulated) {
     // Attempt to abort any pending discoverReader calls first.
     [self abortDiscoverReaders];
 
-    SCPDiscoveryConfiguration *config = [[SCPDiscoveryConfiguration alloc] initWithDeviceType:(SCPDeviceType)deviceType method:(SCPDiscoveryMethod)method];
+    SCPDiscoveryConfiguration *config = [[SCPDiscoveryConfiguration alloc] initWithDeviceType:(SCPDeviceType)deviceType
+                                                                              discoveryMethod:(SCPDiscoveryMethod)method
+                                                                                    simulated:simulated];
     pendingDiscoverReaders = [SCPTerminal.shared discoverReaders:config delegate:self completion:^(NSError * _Nullable error) {
         pendingDiscoverReaders = nil;
         if (error) {
@@ -150,7 +167,7 @@ RCT_EXPORT_METHOD(connectReader:(NSString *)serialNumber ) {
     unsigned long readerIndex = [readers indexOfObjectPassingTest:^(SCPReader *reader, NSUInteger idx, BOOL *stop) {
         return [reader.serialNumber isEqualToString:serialNumber];
     }];
-    
+
     [SCPTerminal.shared connectReader:readers[readerIndex] completion:^(SCPReader * _Nullable reader_, NSError * _Nullable error) {
         reader = reader_;
         if (error) {
@@ -161,12 +178,41 @@ RCT_EXPORT_METHOD(connectReader:(NSString *)serialNumber ) {
     }];
 }
 
+RCT_EXPORT_METHOD(checkForUpdate) {
+    [SCPTerminal.shared checkForUpdate:^(SCPReaderSoftwareUpdate * _Nullable update_, NSError * _Nullable error) {
+        update = update_;
+        if (error) {
+            [self sendEventWithName:@"updateCheck" body:@{@"error": [error localizedDescription]}];
+        } else {
+            [self sendEventWithName:@"updateCheck" body:[self serializeUpdate:update]];
+        }
+    }];
+}
+
+RCT_EXPORT_METHOD(installUpdate) {
+    pendingInstallUpdate = [SCPTerminal.shared installUpdate:update delegate:self completion:^(NSError * _Nullable error) {
+        if (error) {
+            [self sendEventWithName:@"updateInstall" body:@{@"error": [error localizedDescription]}];
+        } else {
+            update = nil;
+            [self sendEventWithName:@"updateInstall" body:@{}];
+        }
+    }];
+}
+
 - (NSDictionary *)serializeReader:(SCPReader *)reader {
     return @{
              @"batteryLevel": reader.batteryLevel ? reader.batteryLevel : @(0),
              @"deviceType": @(reader.deviceType),
              @"serialNumber": reader.serialNumber ? reader.serialNumber : @"",
              @"deviceSoftwareVersion": reader.deviceSoftwareVersion ? reader.deviceSoftwareVersion : @""
+             };
+}
+
+- (NSDictionary *)serializeUpdate:(SCPReaderSoftwareUpdate *)update {
+    return @{
+             @"estimatedUpdateTime": [SCPReaderSoftwareUpdate stringFromUpdateTimeEstimate:update.estimatedUpdateTime],
+             @"deviceSoftwareVersion": update.deviceSoftwareVersion
              };
 }
 
@@ -188,7 +234,7 @@ RCT_EXPORT_METHOD(createPayment:(NSDictionary *)options) {
                                                               @"error": [creationError localizedDescription],
                                                               @"code": @(creationError.code)
                                                               }];
-            
+
         } else {
             pendingCreatePaymentIntent = [SCPTerminal.shared collectPaymentMethod:intent delegate:self completion:^(SCPPaymentIntent * _Nullable collectedIntent, NSError * _Nullable collectionError) {
                 pendingCreatePaymentIntent = nil;
@@ -198,16 +244,16 @@ RCT_EXPORT_METHOD(createPayment:(NSDictionary *)options) {
                                                                             @"code": @(collectionError.code),
                                                                             @"intent": [self serializePaymentIntent:intent]
                                                                             }];
-                    
+
                 } else {
-                    [SCPTerminal.shared confirmPaymentIntent:collectedIntent completion:^(SCPPaymentIntent * _Nullable confirmedIntent, SCPConfirmError * _Nullable confirmationError) {
-                        if (confirmationError) {
+                    [SCPTerminal.shared processPayment:collectedIntent completion:^(SCPPaymentIntent * _Nullable confirmedIntent, SCPProcessPaymentError * _Nullable processError) {
+                        if (processError) {
                             [self sendEventWithName:@"paymentCreation" body:@{
-                                                                                    @"error": [confirmationError localizedDescription],
-                                                                                    @"code": @(confirmationError.code),
+                                                                                    @"error": [processError localizedDescription],
+                                                                                    @"code": @(processError.code),
                                                                                     @"intent": [self serializePaymentIntent:collectedIntent]
                                                                                     }];
-                            
+
                         } else {
                             [self sendEventWithName:@"paymentCreation" body:@{@"intent": [self serializePaymentIntent:confirmedIntent]}];
                         }
@@ -216,18 +262,18 @@ RCT_EXPORT_METHOD(createPayment:(NSDictionary *)options) {
             }];
         }
     };
-    
+
     NSString *paymentIntent = [RCTConvert NSString:options[@"paymentIntent"]];
-    
+
     if (paymentIntent) {
         [SCPTerminal.shared retrievePaymentIntent:paymentIntent completion:onIntent];
-        
+
     } else {
         NSInteger amount = [RCTConvert NSInteger:options[@"amount"]];
         NSString *currency = [RCTConvert NSString:options[@"currency"]];
-        
+
         SCPPaymentIntentParameters *params = [[SCPPaymentIntentParameters alloc] initWithAmount:amount currency:currency];
-        
+
         NSInteger applicationFeeAmount = [RCTConvert NSInteger:options[@"applicationFeeAmount"]];
         if (applicationFeeAmount) {
             params.applicationFeeAmount = [NSNumber numberWithInteger:applicationFeeAmount];
@@ -237,17 +283,97 @@ RCT_EXPORT_METHOD(createPayment:(NSDictionary *)options) {
     }
 }
 
-- (void)terminal:(SCPTerminal *)terminal didBeginWaitingForReaderInput:(SCPReaderInputOptions)inputOptions {
-    [self sendEventWithName:@"didBeginWaitingForReaderInput" body:
+RCT_EXPORT_METHOD(createPaymentIntent:(NSDictionary *)options) {
+    NSInteger amount = [RCTConvert NSInteger:options[@"amount"]];
+    NSString *currency = [RCTConvert NSString:options[@"currency"]];
+
+    SCPPaymentIntentParameters *params = [[SCPPaymentIntentParameters alloc] initWithAmount:amount currency:currency];
+
+    NSInteger applicationFeeAmount = [RCTConvert NSInteger:options[@"applicationFeeAmount"]];
+    if (applicationFeeAmount) {
+        params.applicationFeeAmount = [NSNumber numberWithInteger:applicationFeeAmount];
+    }
+
+    [SCPTerminal.shared createPaymentIntent:params completion:^(SCPPaymentIntent * _Nullable intent_, NSError * _Nullable error) {
+        intent = intent_;
+        if (error) {
+            [self sendEventWithName:@"paymentIntentCreation" body:@{@"error": [error localizedDescription]}];
+        } else {
+            [self sendEventWithName:@"paymentIntentCreation" body:@{@"intent": [self serializePaymentIntent:intent]}];
+        }
+    }];
+}
+
+RCT_EXPORT_METHOD(retrievePaymentIntent:(NSString *)clientSecret) {
+    [SCPTerminal.shared retrievePaymentIntent:clientSecret completion:^(SCPPaymentIntent * _Nullable intent_, NSError * _Nullable error) {
+        intent = intent_;
+        if (error) {
+            [self sendEventWithName:@"paymentIntentRetrieval" body:@{@"error": [error localizedDescription]}];
+        } else {
+            [self sendEventWithName:@"paymentIntentRetrieval" body:@{@"intent": [self serializePaymentIntent:intent]}];
+        }
+    }];
+}
+
+RCT_EXPORT_METHOD(collectPaymentMethod) {
+    pendingCreatePaymentIntent = [SCPTerminal.shared collectPaymentMethod:intent delegate:self completion:^(SCPPaymentIntent * _Nullable collectedIntent, NSError * _Nullable error) {
+        pendingCreatePaymentIntent = nil;
+        if (error) {
+            [self sendEventWithName:@"paymentMethodCollection" body:@{
+                                                                    @"error": [error localizedDescription],
+                                                                    @"code": @(error.code),
+                                                                    @"intent": [self serializePaymentIntent:intent]
+                                                                    }];
+        } else {
+            intent = collectedIntent;
+            [self sendEventWithName:@"paymentMethodCollection" body:@{@"intent": [self serializePaymentIntent:intent]}];
+        }
+    }];
+}
+
+RCT_EXPORT_METHOD(processPayment) {
+    [SCPTerminal.shared processPayment:intent completion:^(SCPPaymentIntent * _Nullable confirmedIntent, SCPProcessPaymentError * _Nullable error) {
+        if (error) {
+            [self sendEventWithName:@"paymentProcess" body:@{
+                @"error": [error localizedDescription],
+                @"code": @(error.code),
+                @"declineCode": error.declineCode ? error.declineCode : @"",
+                @"intent": [self serializePaymentIntent:intent]
+                }];
+
+        } else {
+            intent = confirmedIntent;
+            [self sendEventWithName:@"paymentProcess" body:@{@"intent": [self serializePaymentIntent:confirmedIntent]}];
+        }
+    }];
+}
+
+RCT_EXPORT_METHOD(cancelPaymentIntent) {
+    [SCPTerminal.shared cancelPaymentIntent:intent completion:^(SCPPaymentIntent * _Nullable canceledIntent, NSError * _Nullable error) {
+        if (error) {
+            [self sendEventWithName:@"paymentIntentCancel" body:@{
+                                                                    @"error": [error localizedDescription],
+                                                                    @"code": @(error.code),
+                                                                    @"intent": [self serializePaymentIntent:intent]
+                                                                    }];
+
+        } else {
+            [self sendEventWithName:@"paymentIntentCancel" body:@{@"intent": [self serializePaymentIntent:canceledIntent]}];
+        }
+    }];
+}
+
+- (void)terminal:(SCPTerminal *)terminal didRequestReaderInput:(SCPReaderInputOptions)inputOptions {
+    [self sendEventWithName:@"didRequestReaderInput" body:
      @{
        @"text": [SCPTerminal stringFromReaderInputOptions:inputOptions]
        }];
 }
 
-- (void)terminal:(SCPTerminal *)terminal didRequestReaderInputPrompt:(SCPReaderInputPrompt)inputPrompt {
-    [self sendEventWithName:@"didRequestReaderInputPrompt" body:
+- (void)terminal:(SCPTerminal *)terminal didRequestReaderDisplayMessage:(SCPReaderDisplayMessage)displayMessage {
+    [self sendEventWithName:@"didRequestReaderDisplayMessage" body:
      @{
-       @"text": [SCPTerminal stringFromReaderInputPrompt:inputPrompt]
+       @"text": [SCPTerminal stringFromReaderDisplayMessage:displayMessage]
        }];
 }
 
@@ -255,8 +381,13 @@ RCT_EXPORT_METHOD(createPayment:(NSDictionary *)options) {
     lastReaderEvent = event;
     [self sendEventWithName:@"didReportReaderEvent" body:
      @{
-       @"event": @(event)
+       @"event": @(event),
+       @"info": info ? info : @{}
        }];
+}
+
+- (void)terminal:(SCPTerminal *)terminal didReportLowBatteryWarning:(SCPTerminal *)terminal_ {
+    [self sendEventWithName:@"didReportLowBatteryWarning" body:@{}];
 }
 
 - (void)terminal:(SCPTerminal *)terminal didChangePaymentStatus:(SCPPaymentStatus)status {
@@ -273,8 +404,8 @@ RCT_EXPORT_METHOD(createPayment:(NSDictionary *)options) {
        }];
 }
 
-- (void)terminal:(SCPTerminal *)terminal didDisconnectUnexpectedlyFromReader:(SCPReader *)reader {
-    [self sendEventWithName:@"didDisconnectUnexpectedlyFromReader" body:[self serializeReader:reader]];
+- (void)terminal:(SCPTerminal *)terminal didReportUnexpectedReaderDisconnect:(SCPReader *)reader {
+    [self sendEventWithName:@"didReportUnexpectedReaderDisconnect" body:[self serializeReader:reader]];
 }
 
 RCT_EXPORT_METHOD(clearCachedCredentials) {
@@ -315,7 +446,7 @@ RCT_EXPORT_METHOD(abortCreatePayment) {
         }];
         return;
     }
-    
+
     [self sendEventWithName:@"abortCreatePaymentCompletion" body:@{}];
 }
 
@@ -331,8 +462,23 @@ RCT_EXPORT_METHOD(abortDiscoverReaders) {
         }];
         return;
     }
-    
+
     [self sendEventWithName:@"abortDiscoverReadersCompletion" body:@{}];
+}
+
+RCT_EXPORT_METHOD(abortInstallUpdate) {
+    if (pendingInstallUpdate) {
+        [pendingInstallUpdate cancel:^(NSError * _Nullable error) {
+            if (error) {
+                [self sendEventWithName:@"abortInstallUpdateCompletion" body:@{@"error": [error localizedDescription]}];
+            } else {
+                pendingInstallUpdate = nil;
+                [self sendEventWithName:@"abortInstallUpdateCompletion" body:@{}];
+            }
+        }];
+        return;
+    }
+    [self sendEventWithName:@"abortInstallUpdateCompletion" body:@{}];
 }
 
 RCT_EXPORT_METHOD(getConnectionStatus) {


### PR DESCRIPTION
This commit includes changes to various constant names, events, and event parameters to reflect changes in the SDK from 1.0.0b6 to 1.0.0 (final).  This addresses issue #3.

Specific changes:
- Discovery of simulated reader is now a flag to the `discoverReaders` call rather than a special reader type.
- A number of constants and events changed names.
- Added the ability to remove event listeners.
- Added support for reader software updates.
- Added `createPaymentIntent`, `retrievePaymentIntent`, `collectPaymentMethod`, `processPayment`, and `cancelPaymentIntent` for fine grained control over payment processing.  (The umbrella `createPayment` method still works.)
- Added new events `didRequestReaderInputPrompt` and `didReportLowBatteryWarning`.

You're going to want to review this change very carefully, since I don't know Objective C at all.  However, unlike my previous attempt, I have at least written an app against this and tested it pretty thoroughly (simulator only).
