### PR TITLE
Add “StripeTerminal” as podspec dependency

### DIFF
--- a/RNStripeTerminal.podspec
+++ b/RNStripeTerminal.podspec
@@ -19,4 +19,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React"
+  s.dependency "StripeTerminal"
 end


### PR DESCRIPTION
Hey Theo!

I'm getting back into our card reader project over here, so I'm trying to get switched over to this repo instead of the fork. 

While installing with RN 0.60, I found this podspec dep necessary to build, and then it seems that the new version of RN CLI properly handles the linking! Finally :-D