### PR TITLE
checkForUpdate exception

### DIFF
--- a/ios/RNStripeTerminal.m
+++ b/ios/RNStripeTerminal.m
@@ -213,7 +213,7 @@ RCT_EXPORT_METHOD(installUpdate) {
 - (NSDictionary *)serializeUpdate:(SCPReaderSoftwareUpdate *)update {
     return @{
              @"estimatedUpdateTime": [SCPReaderSoftwareUpdate stringFromUpdateTimeEstimate:update.estimatedUpdateTime],
-             @"deviceSoftwareVersion": update.deviceSoftwareVersion
+             @"deviceSoftwareVersion": update.deviceSoftwareVersion ? update.deviceSoftwareVersion : @""
              };
 }
 


### PR DESCRIPTION
Was getting `*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** -[__NSPlaceholderArray initWithObjects:count:]: attempt to insert nil object from objects[1]'` when checking for bbpos hardware update.

This resolves it. 