### PR TITLE
Fix setting PaymentIntent metadata on Android

### DIFF
--- a/android/src/main/java/com/reactnative_stripeterminal/RNStripeTerminalModule.java
+++ b/android/src/main/java/com/reactnative_stripeterminal/RNStripeTerminalModule.java
@@ -374,10 +374,10 @@ public class RNStripeTerminalModule extends ReactContextBaseJavaModule implement
                 HashMap<String, String> metaDataMap = new HashMap<>();
 
                 if (map != null) {
-                    ReadableMapKeySetIterator iterator = options.keySetIterator();
+                    ReadableMapKeySetIterator iterator = map.keySetIterator();
                     while (iterator.hasNextKey()) {
                         String key = iterator.nextKey();
-                        String val = options.getString(key);
+                        String val = map.getString(key);
                         metaDataMap.put(key, val);
                     }
                 }


### PR DESCRIPTION
There's an error in setting metadata.
`options` in this case is all the params, not metadata.

A way to reproduce the bug:
```
StripeTerminal.createPayment({
        amount: 1200,
        currency: 'usd',
        metadata: {
          orderId: "123"
        }
      })
```