### PR TITLE
Supporting optional updates installation on ios

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ StripeTerminal.createPayment({ amount: 1200, currency: "usd" })
     console.log(error);
   });
 
-// simulator config utils
+// simulator config utils(only on android)
 StripeTerminal.getSimulatorConfiguration().then((config) => {
   console.log("simulator config", config);
 });

--- a/android/src/main/java/com/reactnative_stripeterminal/Constants.java
+++ b/android/src/main/java/com/reactnative_stripeterminal/Constants.java
@@ -78,6 +78,7 @@ public class Constants {
     public static final String UPDATE_TYPE = "updateType";
     public static final String CARD = "card";
     public static final String REQUIRED_AT = "requiredAt";
+    public static final String AVAILABLE_UPDATE = "availableUpdate";
 
     //Plugin Constants
     static{

--- a/android/src/main/java/com/reactnative_stripeterminal/RNStripeTerminalModule.java
+++ b/android/src/main/java/com/reactnative_stripeterminal/RNStripeTerminalModule.java
@@ -149,6 +149,10 @@ public class RNStripeTerminalModule extends ReactContextBaseJavaModule implement
             if (reader.getSoftwareVersion() != null)
                 softwareVersion = reader.getSoftwareVersion();
             writableMap.putString(DEVICE_SOFTWARE_VERSION, softwareVersion);
+
+            if (reader.getAvailableUpdate() != null)
+                writableMap.putMap(AVAILABLE_UPDATE, serializeUpdate(reader.getAvailableUpdate()));
+
         }
         return writableMap;
     }

--- a/index.js
+++ b/index.js
@@ -1,16 +1,16 @@
-import { NativeModules, NativeEventEmitter, Platform } from 'react-native';
+import { NativeModules, NativeEventEmitter, Platform } from "react-native";
 
-import createHooks from './hooks';
-import createConnectionService from './connectionService';
-import { filterAndRenameObj } from './utils';
+import createHooks from "./hooks";
+import createConnectionService from "./connectionService";
+import { filterAndRenameObj } from "./utils";
 
 const { RNStripeTerminal } = NativeModules;
 
 const constants = RNStripeTerminal.getConstants();
 
-export const readerUpdateTypes = filterAndRenameObj(constants, 'ReaderUpdate');
+export const readerUpdateTypes = filterAndRenameObj(constants, "ReaderUpdate");
 
-export const simulatedCardTypes = filterAndRenameObj(constants, 'Card');
+export const simulatedCardTypes = filterAndRenameObj(constants, "Card");
 
 class StripeTerminal {
   // Device types
@@ -38,10 +38,8 @@ class StripeTerminal {
   // Payment status
   PaymentStatusNotReady = RNStripeTerminal.PaymentStatusNotReady;
   PaymentStatusReady = RNStripeTerminal.PaymentStatusReady;
-  PaymentStatusWaitingForInput =
-    RNStripeTerminal.PaymentStatusWaitingForInput;
-  PaymentStatusProcessing =
-    RNStripeTerminal.PaymentStatusProcessing;
+  PaymentStatusWaitingForInput = RNStripeTerminal.PaymentStatusWaitingForInput;
+  PaymentStatusProcessing = RNStripeTerminal.PaymentStatusProcessing;
 
   // Connection status
   ConnectionStatusNotConnected = RNStripeTerminal.ConnectionStatusNotConnected;
@@ -50,53 +48,61 @@ class StripeTerminal {
 
   // Fetch connection token. Overwritten in call to initialize
   _fetchConnectionToken = () =>
-    Promise.reject('You must initialize RNStripeTerminal first.');
+    Promise.reject("You must initialize RNStripeTerminal first.");
 
   constructor() {
     this.listener = new NativeEventEmitter(RNStripeTerminal);
 
-    this.listener.addListener('requestConnectionToken', () => {
+    this.listener.addListener("requestConnectionToken", () => {
       this._fetchConnectionToken()
-        .then(token => {
+        .then((token) => {
           if (token) {
             RNStripeTerminal.setConnectionToken(token, null);
           } else {
-            throw new Error('User-supplied `fetchConnectionToken` resolved successfully, but no token was returned.');
+            throw new Error(
+              "User-supplied `fetchConnectionToken` resolved successfully, but no token was returned."
+            );
           }
         })
-        .catch(err => RNStripeTerminal.setConnectionToken(null, err.message || 'Error in user-supplied `fetchConnectionToken`.'));
+        .catch((err) =>
+          RNStripeTerminal.setConnectionToken(
+            null,
+            err.message || "Error in user-supplied `fetchConnectionToken`."
+          )
+        );
     });
 
     this._createListeners([
-      'log',
-      'readersDiscovered',
-      'abortDiscoverReadersCompletion',
-      'didRequestReaderInput',
-      'didRequestReaderDisplayMessage',
-      'didReportReaderEvent',
-      'didReportLowBatteryWarning',
-      'didChangePaymentStatus',
-      'didChangeConnectionStatus',
-      'didReportUnexpectedReaderDisconnect',
-      'didReportAvailableUpdate',
-      'didStartInstallingUpdate',
-      'didReportReaderSoftwareUpdateProgress',
-      'didFinishInstallingUpdate'
+      "log",
+      "readersDiscovered",
+      "abortDiscoverReadersCompletion",
+      "didRequestReaderInput",
+      "didRequestReaderDisplayMessage",
+      "didReportReaderEvent",
+      "didReportLowBatteryWarning",
+      "didChangePaymentStatus",
+      "didChangeConnectionStatus",
+      "didReportUnexpectedReaderDisconnect",
+      "didReportAvailableUpdate",
+      "didStartInstallingUpdate",
+      "didReportReaderSoftwareUpdateProgress",
+      "didFinishInstallingUpdate",
     ]);
   }
 
   _createListeners(keys) {
-    keys.forEach(k => {
-      this[`add${k[0].toUpperCase() + k.substring(1)}Listener`] = listener =>
+    keys.forEach((k) => {
+      this[`add${k[0].toUpperCase() + k.substring(1)}Listener`] = (listener) =>
         this.listener.addListener(k, listener);
-      this[`remove${k[0].toUpperCase() + k.substring(1)}Listener`] = listener =>
-        this.listener.removeListener(k, listener);
+      this[`remove${k[0].toUpperCase() + k.substring(1)}Listener`] = (
+        listener
+      ) => this.listener.removeListener(k, listener);
     });
   }
 
   _wrapPromiseReturn(event, call, key) {
     return new Promise((resolve, reject) => {
-      const subscription = this.listener.addListener(event, data => {
+      const subscription = this.listener.addListener(event, (data) => {
         if (data && data.error) {
           reject(data);
         } else {
@@ -111,162 +117,174 @@ class StripeTerminal {
 
   initialize({ fetchConnectionToken }) {
     this._fetchConnectionToken = fetchConnectionToken;
-    return new Promise((resolve, reject)=>{
-    if(Platform.OS === "android"){
-      RNStripeTerminal.initialize((status)=>{
-        if(status.isInitialized === true){
-          resolve()
-        }else{
-          reject(status.error);
-        }
-      });
-    }else{
-      RNStripeTerminal.initialize();
-      resolve();
-    }
-  });
+    return new Promise((resolve, reject) => {
+      if (Platform.OS === "android") {
+        RNStripeTerminal.initialize((status) => {
+          if (status.isInitialized === true) {
+            resolve();
+          } else {
+            reject(status.error);
+          }
+        });
+      } else {
+        RNStripeTerminal.initialize();
+        resolve();
+      }
+    });
   }
 
   getSimulatorConfiguration() {
-    return RNStripeTerminal.getSimulatorConfiguration();
+    if (Platform.OS === "android") {
+      return RNStripeTerminal.getSimulatorConfiguration();
+    } else {
+      return Promise.reject("getSimulatorConfig not supported on iOS");
+    }
   }
-  
-  setSimulatorConfiguration(updateType, cardNumber, cardType){
-    return RNStripeTerminal.setSimulatorConfiguration(updateType || -1, cardNumber || null, cardType || -1);
+
+  setSimulatorConfiguration(updateType, cardNumber, cardType) {
+    if (Platform.OS === "android") {
+      return RNStripeTerminal.setSimulatorConfiguration(
+        updateType || -1,
+        cardNumber || null,
+        cardType || -1
+      );
+    } else {
+      return Promise.reject("getSimulatorConfig not supported on iOS");
+    }
   }
 
   discoverReaders(method, simulated) {
-    return this._wrapPromiseReturn('readersDiscovered', () => {
+    return this._wrapPromiseReturn("readersDiscovered", () => {
       RNStripeTerminal.discoverReaders(method, simulated);
     });
   }
 
   installUpdate() {
-      return RNStripeTerminal.installUpdate();
+    return RNStripeTerminal.installUpdate();
   }
 
   connectReader(serialNumber, locationId) {
-    return this._wrapPromiseReturn('readerConnection', () => {
+    return this._wrapPromiseReturn("readerConnection", () => {
       RNStripeTerminal.connectReader(serialNumber, locationId);
     });
   }
 
   disconnectReader() {
-    return this._wrapPromiseReturn('readerDisconnectCompletion', () => {
+    return this._wrapPromiseReturn("readerDisconnectCompletion", () => {
       RNStripeTerminal.disconnectReader();
     });
   }
 
   getConnectedReader() {
-    return this._wrapPromiseReturn('connectedReader', () => {
+    return this._wrapPromiseReturn("connectedReader", () => {
       RNStripeTerminal.getConnectedReader();
-    }).then(data => (data.serialNumber ? data : null));
+    }).then((data) => (data.serialNumber ? data : null));
   }
 
   getConnectionStatus() {
-    return this._wrapPromiseReturn('connectionStatus', () => {
+    return this._wrapPromiseReturn("connectionStatus", () => {
       RNStripeTerminal.getConnectionStatus();
     });
   }
 
   getPaymentStatus() {
-    return this._wrapPromiseReturn('paymentStatus', () => {
+    return this._wrapPromiseReturn("paymentStatus", () => {
       RNStripeTerminal.getPaymentStatus();
     });
   }
 
   getLastReaderEvent() {
-    return this._wrapPromiseReturn('lastReaderEvent', () => {
+    return this._wrapPromiseReturn("lastReaderEvent", () => {
       RNStripeTerminal.getLastReaderEvent();
     });
   }
 
   createPayment(options) {
     return this._wrapPromiseReturn(
-      'paymentCreation',
+      "paymentCreation",
       () => {
         RNStripeTerminal.createPayment(options);
       },
-      'intent',
+      "intent"
     );
   }
 
   createPaymentIntent(options) {
     return this._wrapPromiseReturn(
-      'paymentIntentCreation',
+      "paymentIntentCreation",
       () => {
         RNStripeTerminal.createPaymentIntent(options);
       },
-      'intent'
+      "intent"
     );
   }
 
   retrievePaymentIntent(clientSecret) {
     return this._wrapPromiseReturn(
-      'paymentIntentRetrieval',
+      "paymentIntentRetrieval",
       () => {
         RNStripeTerminal.retrievePaymentIntent(clientSecret);
       },
-      'intent'
+      "intent"
     );
   }
 
   collectPaymentMethod() {
     return this._wrapPromiseReturn(
-      'paymentMethodCollection',
+      "paymentMethodCollection",
       () => {
         RNStripeTerminal.collectPaymentMethod();
       },
-      'intent'
+      "intent"
     );
   }
 
   processPayment() {
     return this._wrapPromiseReturn(
-      'paymentProcess',
+      "paymentProcess",
       () => {
         RNStripeTerminal.processPayment();
       },
-      'intent'
+      "intent"
     );
   }
 
   cancelPaymentIntent() {
     return this._wrapPromiseReturn(
-      'paymentIntentCancel',
+      "paymentIntentCancel",
       () => {
         RNStripeTerminal.cancelPaymentIntent();
       },
-      'intent'
+      "intent"
     );
   }
 
   abortCreatePayment() {
-    return this._wrapPromiseReturn('abortCreatePaymentCompletion', () => {
+    return this._wrapPromiseReturn("abortCreatePaymentCompletion", () => {
       RNStripeTerminal.abortCreatePayment();
     });
   }
 
   abortDiscoverReaders() {
-    return this._wrapPromiseReturn('abortDiscoverReadersCompletion', () => {
+    return this._wrapPromiseReturn("abortDiscoverReadersCompletion", () => {
       RNStripeTerminal.abortDiscoverReaders();
     });
   }
 
   abortInstallUpdate() {
-    return this._wrapPromiseReturn('abortInstallUpdateCompletion', () => {
+    return this._wrapPromiseReturn("abortInstallUpdateCompletion", () => {
       RNStripeTerminal.abortInstallUpdate();
-    })
+    });
   }
 
   startService(options) {
-    if (typeof options === 'string') {
+    if (typeof options === "string") {
       options = { policy: options };
     }
 
     if (this._currentService) {
       return Promise.reject(
-        'A service is already running. You must stop it using `stopService` before starting a new service.',
+        "A service is already running. You must stop it using `stopService` before starting a new service."
       );
     }
 

--- a/ios/RNStripeTerminal.h
+++ b/ios/RNStripeTerminal.h
@@ -17,7 +17,7 @@
     NSArray<SCPReader *> *readers;
     SCPReader *reader;
     SCPPaymentIntent *intent;
-    SCPReaderSoftwareUpdate *update;
+    SCPReaderSoftwareUpdate *readerSoftwareUpdate;
     SCPCancelable *pendingReadPaymentMethod;
     SCPCancelable *pendingCreatePaymentIntent;
     SCPCancelable *pendingDiscoverReaders;

--- a/ios/RNStripeTerminal.m
+++ b/ios/RNStripeTerminal.m
@@ -27,12 +27,9 @@ static dispatch_once_t onceToken = 0;
              @"log",
              @"requestConnectionToken",
              @"readersDiscovered",
-             @"readerSoftwareUpdateProgress",
              @"readerDiscoveryCompletion",
              @"readerDisconnectCompletion",
              @"readerConnection",
-             @"updateCheck",
-             @"updateInstall",
              @"paymentCreation",
              @"paymentIntentCreation",
              @"paymentIntentRetrieval",
@@ -106,10 +103,6 @@ static dispatch_once_t onceToken = 0;
     [self sendEventWithName:@"readersDiscovered" body:data];
 }
 
-- (void)terminal:(SCPTerminal *)terminal didReportReaderSoftwareUpdateProgress:(float)progress {
-    [self sendEventWithName:@"readerSoftwareUpdateProgress" body:[NSNumber numberWithFloat:progress]];
-}
-
 - (void)onLogEntry:(NSString * _Nonnull) logline {
     if (self.bridge == nil) {
         return;
@@ -172,7 +165,7 @@ RCT_EXPORT_METHOD(connectReader:(NSString *)serialNumber location:(NSString *)lo
         return [reader.serialNumber isEqualToString:serialNumber];
     }];
 
-    SCPTerminal.shared.simulatorConfiguration.availableReaderUpdate = SCPSimulateReaderUpdateRequired;
+    SCPTerminal.shared.simulatorConfiguration.availableReaderUpdate = SCPSimulateReaderUpdateRandom;
     SCPBluetoothConnectionConfiguration *connectionConfig = [[SCPBluetoothConnectionConfiguration alloc] initWithLocationId:locationId];
     [SCPTerminal.shared connectBluetoothReader:readers[readerIndex] delegate: self
                                                             connectionConfig: connectionConfig
@@ -195,23 +188,35 @@ RCT_EXPORT_METHOD(connectReader:(NSString *)serialNumber location:(NSString *)lo
              @"deviceType": @(reader.deviceType),
              @"serialNumber": reader.serialNumber ? reader.serialNumber : @"",
              @"deviceSoftwareVersion": reader.deviceSoftwareVersion ? reader.deviceSoftwareVersion : @"",
-             @"availableUpdate": reader.availableUpdate ? reader.availableUpdate : @"",
+             @"availableUpdate": reader.availableUpdate ? [self serializeUpdate:reader.availableUpdate] : @{},
              };
 }
 
 - (NSDictionary *)serializeUpdate:(SCPReaderSoftwareUpdate *)update {
-    NSDictionary *updateDict = @{
-                @"estimatedUpdateTime": [SCPReaderSoftwareUpdate stringFromUpdateTimeEstimate:update.estimatedUpdateTime],
-                @"deviceSoftwareVersion": update.deviceSoftwareVersion ? update.deviceSoftwareVersion : @"",
-                @"requiredAt": update.requiredAt,
-    };
-    return @{ @"update": updateDict};
+    NSDictionary *updateDict = @{};
+    if(update){
+        NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
+        [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ssZZZZ"];
+        NSString *requiredAt = [formatter stringFromDate:update.requiredAt];
+        
+        updateDict = @{
+                    @"estimatedUpdateTime": [SCPReaderSoftwareUpdate stringFromUpdateTimeEstimate:update.estimatedUpdateTime],
+                    @"deviceSoftwareVersion": update.deviceSoftwareVersion ? update.deviceSoftwareVersion : @"",
+                    @"requiredAt": requiredAt,
+        };
+        return @{ @"update": updateDict};
+    }
+    return updateDict;
 }
 
 - (NSDictionary *)serializePaymentIntent:(SCPPaymentIntent *)intent {
+    NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
+    [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ssZZZZ"];
+    NSString *createdDate = [formatter stringFromDate:intent.created];
+    
     return @{
              @"stripeId": intent.stripeId,
-             @"created": intent.created,
+             @"created": createdDate,
              @"status": @(intent.status),
              @"amount": @(intent.amount),
              @"currency": intent.currency,
@@ -410,12 +415,14 @@ RCT_EXPORT_METHOD(cancelPaymentIntent) {
         [self sendEventWithName:@"didFinishInstallingUpdate" body:@{@"error": [error localizedDescription]}];
     } else {
         pendingInstallUpdate = nil;
+        readerSoftwareUpdate = nil;
         [self sendEventWithName:@"didFinishInstallingUpdate" body:update ? [self serializeUpdate:update] : @{}];
     }
 }
 
 - (void)reader:(nonnull SCPReader *)reader didReportAvailableUpdate:(nonnull SCPReaderSoftwareUpdate *)update {
-   [self sendEventWithName:@"didReportAvailableUpdate" body:@{}];
+    readerSoftwareUpdate = update;
+   [self sendEventWithName:@"didReportAvailableUpdate" body:[self serializeUpdate:update]];
 }
 
 - (void)reader:(nonnull SCPReader *)reader didReportReaderSoftwareUpdateProgress:(float)progress {
@@ -423,6 +430,7 @@ RCT_EXPORT_METHOD(cancelPaymentIntent) {
 }
 
 - (void)reader:(nonnull SCPReader *)reader didStartInstallingUpdate:(nonnull SCPReaderSoftwareUpdate *)update cancelable:(nullable SCPCancelable *)cancelable {
+    readerSoftwareUpdate = update;
     pendingInstallUpdate = cancelable;
     [self sendEventWithName:@"didStartInstallingUpdate" body:update ? [self serializeUpdate:update] : @{}];
 }
@@ -453,8 +461,16 @@ RCT_EXPORT_METHOD(getConnectedReader) {
      reader ? [self serializeReader:reader] : @{}];
 }
 
+RCT_EXPORT_METHOD(installUpdate:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    if (readerSoftwareUpdate) {
+        [SCPTerminal.shared installAvailableUpdate];
+    }
+    resolve([self serializeUpdate:readerSoftwareUpdate]);
+}
+
 RCT_EXPORT_METHOD(abortCreatePayment) {
-    if (pendingCreatePaymentIntent) {
+    if (pendingCreatePaymentIntent && !pendingCreatePaymentIntent.completed) {
         [pendingCreatePaymentIntent cancel:^(NSError * _Nullable error) {
             if (error) {
                 [self sendEventWithName:@"abortCreatePaymentCompletion" body:@{@"error": [error localizedDescription]}];
@@ -470,7 +486,7 @@ RCT_EXPORT_METHOD(abortCreatePayment) {
 }
 
 RCT_EXPORT_METHOD(abortDiscoverReaders) {
-    if (pendingDiscoverReaders) {
+    if (pendingDiscoverReaders && !pendingDiscoverReaders.completed) {
         [pendingDiscoverReaders cancel:^(NSError * _Nullable error) {
             if (error) {
                 [self sendEventWithName:@"abortDiscoverReadersCompletion" body:@{@"error": [error localizedDescription]}];
@@ -486,7 +502,7 @@ RCT_EXPORT_METHOD(abortDiscoverReaders) {
 }
 
 RCT_EXPORT_METHOD(abortInstallUpdate) {
-    if (pendingInstallUpdate) {
+    if (pendingInstallUpdate && !pendingInstallUpdate.completed) {
         [pendingInstallUpdate cancel:^(NSError * _Nullable error) {
             if (error) {
                 [self sendEventWithName:@"abortInstallUpdateCompletion" body:@{@"error": [error localizedDescription]}];


### PR DESCRIPTION
- restricting get and set simulatorConfig to android
- setting default simulator config update type to random in ios
- converting date to string ios(in serializeUpdate and serializePaymentIntent)
- appending availableUpdate object to reader object(android)
- cleanup